### PR TITLE
Migrate project to go module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IntelliJ related files
+.idea
+*.iml

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module gitub.com/stryda/prompt
+
+go 1.13


### PR DESCRIPTION
This pull request migrates the project to a go module and updates the `gitignore` to ignore IntelliJ related files